### PR TITLE
Move options to `setup.cfg` + best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+tags
+.pytest_cache
+
 # Temporary and binary files
 *~
 *.py[cod]

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+line_length=79
+indent='    '
+skip=.tox,.venv,build,dist
+known_setuptools=setuptools,pkg_resources
+known_compat=six
+known_test=pytest
+known_first_party=pyscaffoldext
+sections=FUTURE,STDLIB,SETUPTOOLS,COMPAT,TEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section=THIRDPARTY
+multi_line_output=3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+exclude: '^(.tox|build|dist|.eggs|docs/conf.py|docs/gfx)'
+
+repos:
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  rev: v1.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: check-added-large-files
+  - id: check-ast
+  - id: check-json
+  - id: check-merge-conflict
+  - id: check-xml
+  - id: check-yaml
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: requirements-txt-fixer
+  - id: mixed-line-ending
+    args: ['--fix=no']
+  - id: flake8
+
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.4
+  hooks:
+  - id: isort

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+# Travis configuration file using the build matrix feature
+# Read more under http://docs.travis-ci.com/user/build-configuration/
+# THIS SCRIPT IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
+
+sudo: false
+language: python
+virtualenv:
+  system_site_packages: true
+matrix:
+  include:
+    - python: 3.4
+      env: DISTRIB="ubuntu" TOX_PYTHON_VERSION="py34" COVERAGE="true"
+    - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
+addons:
+  apt:
+    packages:
+      - git
+install:
+  - source tests/travis_install.sh
+before_script:
+  - git config --global user.email "you@example.com"
+  - git config --global user.name "Your Name"
+script:
+  - tox
+after_success:
+  - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
+cache:
+  apt: true
+  pip: true
+  directories:
+    - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,11 @@ script:
   - tox
 after_success:
   - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
+after_script:
+  - travis-cleanup
 cache:
   apt: true
   pip: true
   directories:
     - $HOME/.cache/pip
+    - $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ matrix:
     - python: 3.4
       env: DISTRIB="ubuntu" TOX_PYTHON_VERSION="py34" COVERAGE="true"
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
-addons:
-  apt:
-    packages:
-      - git
 install:
   - source tests/travis_install.sh
 before_script:
@@ -27,7 +23,6 @@ after_success:
 after_script:
   - travis-cleanup
 cache:
-  apt: true
   pip: true
   directories:
     - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ before_script:
   - git config --global user.name "Your Name"
 script:
   - tox
+  - |
+    if [[ "$COVERAGE" == "true" ]]; then
+      pre-commit install
+      pre-commit run --all-files
+    fi
 after_success:
   - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
 after_script:

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/pyscaffold/pyscaffoldext-pyproject.svg?branch=master
+    :target: https://travis-ci.org/pyscaffold/pyscaffoldext-pyproject
+
 =======================
 pyscaffoldext-pyproject
 =======================

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@
 # Example:
 # numpy==1.13.3
 # scipy==1.0
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ norecursedirs =
     dist
     build
     .tox
+testpaths = tests
 
 [aliases]
 release = sdist bdist_wheel upload

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ package_dir =
 install_requires = pyscaffold
 # Add here test requirements (semicolon-separated)
 tests_require = pytest; pytest-cov
+# Used only for `python setup.py test`. See extras-require for tox
 
 [options.packages.find]
 where = src
@@ -39,6 +40,9 @@ exclude =
 # Add here additional requirements for extra features, to install with:
 # `pip install pyscaffoldext-pyproject[PDF]` like:
 # PDF = ReportLab; RXP
+testing =
+    pytest
+    pytest-cov
 
 [test]
 # py.test options when running `python setup.py test`

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ packages = find:
 include_package_data = True
 package_dir =
     =src
+setup_requires =
+    pyscaffold>=3.0a0,<3.1a0
 # Add here dependencies of your project (semicolon-separated), e.g.
 # install_requires = numpy; scipy
 install_requires = pyscaffold
@@ -43,6 +45,11 @@ exclude =
 testing =
     pytest
     pytest-cov
+
+
+[options.entry_points]
+pyscaffold.cli =
+    pyproject = pyscaffoldext.pyproject.extension:PyProject
 
 [test]
 # py.test options when running `python setup.py test`

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,5 @@
 """
 from setuptools import setup
 
-
 if __name__ == "__main__":
     setup(use_pyscaffold=True)

--- a/setup.py
+++ b/setup.py
@@ -7,24 +7,8 @@
     PyScaffold helps you to put up the scaffold of your new Python project.
     Learn more under: http://pyscaffold.org/
 """
-
-import sys
 from setuptools import setup
-
-# Register the entry_point so that PyScaffold finds this extension
-entry_points = """
-[pyscaffold.cli]
-pyproject = pyscaffoldext.pyproject.extension:PyProject
-"""
-
-
-def setup_package():
-    needs_sphinx = {'build_sphinx', 'upload_docs'}.intersection(sys.argv)
-    sphinx = ['sphinx'] if needs_sphinx else []
-    setup(setup_requires=['pyscaffold>=3.0a0,<3.1a0'] + sphinx,
-          entry_points=entry_points,
-          use_pyscaffold=True)
 
 
 if __name__ == "__main__":
-    setup_package()
+    setup(use_pyscaffold=True)

--- a/src/pyscaffoldext/pyproject/extension.py
+++ b/src/pyscaffoldext/pyproject/extension.py
@@ -3,8 +3,7 @@
 Implementation of a simple extension that additionally
 adds the file pyproject.toml
 """
-from pyscaffold.api import Extension
-from pyscaffold.api import helpers
+from pyscaffold.api import Extension, helpers
 
 from .templates import pyproject_toml
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,6 @@
     Read more about conftest.py under:
     https://pytest.org/latest/plugins.html
 """
-from __future__ import print_function, absolute_import, division
+from __future__ import absolute_import, division, print_function
 
 # import pytest

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -7,6 +7,7 @@ import pytest
 
 from pyscaffold.api import create_project
 from pyscaffold.cli import run
+
 from pyscaffoldext.pyproject.extension import PyProject
 
 

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import sys
+from os.path import exists as path_exists
+
+import pytest
+
+from pyscaffold.api import create_project
+from pyscaffold.cli import run
+from pyscaffoldext.pyproject.extension import PyProject
+
+
+@pytest.fixture
+def tmpfolder(tmpdir):
+    """Create a temporary folder, chdir into it and execute the test.
+
+    Additionally inject the tmpdir object as parameter in the test functions.
+    """
+    with tmpdir.as_cwd():
+        yield tmpdir
+
+
+def test_create_project_with_pyproject(tmpfolder):
+    # Given options with the pyproject extension,
+    opts = dict(project="proj",
+                extensions=[PyProject('pyproject')])
+
+    # when the project is created,
+    create_project(opts)
+
+    # then pyproject files should exist
+    assert path_exists("proj/pyproject.toml")
+
+
+def test_create_project_without_pyproject(tmpfolder):
+    # Given options without the pyproject extension,
+    opts = dict(project="proj")
+
+    # when the project is created,
+    create_project(opts)
+
+    # then pyproject files should not exist
+    assert not path_exists("proj/pyproject.toml")
+
+
+def test_cli_with_pyproject(tmpfolder):
+    # Given the command line with the pyproject option,
+    sys.argv = ["pyscaffold", "--pyproject", "proj"]
+
+    # when pyscaffold runs,
+    run()
+
+    # then pyproject files should exist
+    assert path_exists("proj/pyproject.toml")
+
+
+def test_cli_without_pyproject(tmpfolder):
+    # Given the command line without the pyproject option,
+    sys.argv = ["pyscaffold", "proj"]
+
+    # when pyscaffold runs,
+    run()
+
+    # then pyproject files should not exist
+    assert not path_exists("proj/pyproject.toml")

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This script is meant to be called by the "install" step defined in
+# .travis.yml. See http://docs.travis-ci.com/ for more details.
+# The behavior of the script is controlled by environment variabled defined
+# in the .travis.yml in the top level folder of the project.
+#
+# This script is taken from Scikit-Learn (http://scikit-learn.org/)
+#
+# THIS SCRIPT IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
+
+set -e
+
+if [[ "$DISTRIB" == "conda" ]]; then
+    # Deactivate the travis-provided virtual environment and setup a
+    # conda-based environment instead
+    deactivate
+
+    # Use the miniconda installer for faster download / install of conda
+    # itself
+    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+        -O miniconda.sh
+    chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+    export PATH=$HOME/miniconda/bin:$PATH
+    conda update --yes conda
+
+    # Configure the conda environment and put it in the path using the
+    # provided versions
+    conda create -n testenv --yes python=${PYTHON_VERSION} pip virtualenv
+    source activate testenv
+fi
+
+
+if [[ "$COVERAGE" == "true" ]]; then
+    pip install coverage coveralls
+fi
+# for all
+pip install -U pip setuptools
+pip install sphinx
+pip install tox

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -15,25 +15,44 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # conda-based environment instead
     deactivate
 
-    # Use the miniconda installer for faster download / install of conda
-    # itself
-    wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-        -O miniconda.sh
-    chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+    if [[ -f "$HOME/miniconda/bin/conda" ]]; then
+        echo "Skip install conda"
+    else
+      rm -rf "$HOME/miniconda"
+      # ^  Caching creates empty dir that conflicts with conda installer
+
+      # Use the miniconda installer for faster download / install of conda
+      # itself
+      wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+          -O miniconda.sh
+      chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+    fi
     export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 
     # Configure the conda environment and put it in the path using the
     # provided versions
-    conda create -n testenv --yes python=${PYTHON_VERSION} pip virtualenv
-    source activate testenv
+    conda create -p ./.venv --yes python=${PYTHON_VERSION} pip virtualenv
+    source activate ./.venv
 fi
 
 
 if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls
 fi
+
 # for all
 pip install -U pip setuptools
 pip install sphinx
 pip install tox
+
+travis-cleanup() {
+  printf "Cleaning up environments ... "  # printf avoids new lines
+  if [[ "$DISTRIB" == "conda" ]]; then
+    # Force the env to be recreated next time, for build consistency
+    source deactivate
+    conda remove -p ./.venv --all --yes
+    rm -rf ./.venv
+  fi
+  echo "DONE"
+}

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -38,7 +38,7 @@ fi
 
 
 if [[ "$COVERAGE" == "true" ]]; then
-    pip install coverage coveralls
+    pip install coverage coveralls pre-commit
 fi
 
 # for all

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+minversion = 1.8
+
+[testenv]
+passenv =
+    HOME
+commands =
+    py.test {posargs}
+extras = testing


### PR DESCRIPTION
This PR is aligned with [PyScaffold#176](https://github.com/blue-yonder/pyscaffold/issues/176) and
moves `setup_requires` and `entry_points` from `setup.py` to `setup.cfg`.

Additionally, it adds some tests and verifications with Travis help.